### PR TITLE
Allow the base URL for API calls to be customized

### DIFF
--- a/src/@types.ts
+++ b/src/@types.ts
@@ -104,6 +104,11 @@ export interface Config {
    * larger with each try until you hit the maxRetry amount
    */
   retryTimeout?: number;
+  /**
+   * @default=https://api.airtable.com/v0
+   * The endpoint to make API calls against. This is useful when setting up a custom caching server as succested in the Airtable API docs
+   */
+  baseURL?: string;
 }
 
 /** @ignore */

--- a/src/asyncAirtable.ts
+++ b/src/asyncAirtable.ts
@@ -62,6 +62,8 @@ class AsyncAirtable {
   apiKey: string;
   /** The base id from AirTable */
   base: string;
+  /** the base URL to use when making API requests */
+  baseURL: string;
 
   /**
    * Creates a new instance of the AsyncAirtable library.
@@ -77,6 +79,7 @@ class AsyncAirtable {
     this.retryOnRateLimit = config?.retryOnRateLimit || true;
     this.retryTimeout = config?.retryTimeout || 5000;
     this.maxRetry = config?.maxRetry || 60000;
+    this.baseURL = config?.baseURL || 'https://api.airtable.com/v0';
   }
 
   /**

--- a/src/asyncAirtable.ts
+++ b/src/asyncAirtable.ts
@@ -3,7 +3,6 @@ import buildOpts from './buildOpts';
 import checkError from './checkError';
 import checkArg from './checkArg';
 import rateLimitHandler from './rateLimitHandler';
-const baseURL = 'https://api.airtable.com/v0';
 import {
   SelectOptions,
   AirtableDeletedResponse,
@@ -99,7 +98,7 @@ class AsyncAirtable {
       checkArg(table, 'table', 'string');
       checkArg(options, 'options', 'object', false);
       checkArg(page, 'page', 'number', false);
-      const url = `${baseURL}/${this.base}/${table}`;
+      const url = `${this.baseURL}/${this.base}/${table}`;
       const opts: SelectOptions = options ? { ...options } : {};
       Object.keys(opts).forEach((option) => {
         if (!validOptions.includes(option)) {
@@ -200,7 +199,7 @@ class AsyncAirtable {
     try {
       checkArg(table, 'table', 'string');
       checkArg(id, 'id', 'string');
-      const url = `${baseURL}/${this.base}/${table}/${id}`;
+      const url = `${this.baseURL}/${this.base}/${table}/${id}`;
       const res: Response = await fetch(url, {
         headers: { Authorization: `Bearer ${this.apiKey}` },
       });
@@ -244,7 +243,7 @@ class AsyncAirtable {
       checkArg(table, 'table', 'string');
       checkArg(record, 'record', 'object');
       checkArg(typecast, 'typecast', 'boolean', false);
-      const url = `${baseURL}/${this.base}/${table}`;
+      const url = `${this.baseURL}/${this.base}/${table}`;
       const body: queryBody = { fields: record };
       if (typecast !== undefined) {
         body.typecast = typecast;
@@ -305,7 +304,7 @@ class AsyncAirtable {
         checkArg(opts.destructive, 'opts.desctructive', 'boolean');
         checkArg(opts.typecast, 'opts.typecast', 'boolean', false);
       }
-      const url = `${baseURL}/${this.base}/${table}/${record.id}`;
+      const url = `${this.baseURL}/${this.base}/${table}/${record.id}`;
       const body: queryBody = { fields: record.fields };
       if (opts?.typecast !== undefined) {
         body.typecast = opts?.typecast;
@@ -357,7 +356,7 @@ class AsyncAirtable {
     try {
       checkArg(table, 'table', 'string');
       checkArg(id, 'id', 'string');
-      const url = `${baseURL}/${this.base}/${table}/${id}`;
+      const url = `${this.baseURL}/${this.base}/${table}/${id}`;
       const res: Response = await fetch(url, {
         method: 'delete',
         headers: {
@@ -407,7 +406,7 @@ class AsyncAirtable {
       checkArg(table, 'table', 'string');
       checkArg(records, 'records', 'array');
       checkArg(typecast, 'typecast', 'boolean', false);
-      const url = `${baseURL}/${this.base}/${table}`;
+      const url = `${this.baseURL}/${this.base}/${table}`;
       const body: bulkQueryBody = {
         records: records.map((record) => ({
           fields: record,
@@ -473,7 +472,7 @@ class AsyncAirtable {
         checkArg(opts.destructive, 'opts.desctructive', 'boolean', false);
         checkArg(opts.typecast, 'opts.typecast', 'boolean', false);
       }
-      const url = `${baseURL}/${this.base}/${table}`;
+      const url = `${this.baseURL}/${this.base}/${table}`;
       const body: bulkQueryBody = { records };
       if (opts?.typecast !== undefined) {
         body.typecast = opts?.typecast;
@@ -537,7 +536,7 @@ class AsyncAirtable {
           query = `records[]=${id}`;
         }
       });
-      const url = `${baseURL}/${this.base}/${table}?${encodeURI(query)}`;
+      const url = `${this.baseURL}/${this.base}/${table}?${encodeURI(query)}`;
       const res: Response = await fetch(url, {
         method: 'delete',
         headers: {


### PR DESCRIPTION
I didn't see any documentation for this behavior and it seemed easy enough to add.

The Airtable API docs say that API calls are limited to 5 requests per base per second with a 30 second cooldown if you violate it. The docs suggest setting up a caching proxy to get around this, which would require changing the baseURL that API calls are made against.

This PR adds a `baseURL` option to the `Config` object passed into the AsyncAirtable constructor to override the default baseURL value.